### PR TITLE
Removed Localication and Rendered Tabs

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -20,14 +20,12 @@ define([
         title: "Fields"
         , collection: new SnippetsCollection(JSON.parse(fieldsJSON))
       });
+      /* This Tab will be useful later when more languages are supported
       new TabView({
         title: "Localization"
         , content: localizationTab
       });
-      new TabView({
-        title: "Rendered"
-        , content: renderTab
-      });
+      */
       new TabView({
         title: "About"
         , content: aboutTab


### PR DESCRIPTION
The localization tab isn't yet useful, and the Rendered Tab is a remnant of the project we originally forked and is not useful to the workflow in any capacity.